### PR TITLE
persistable bug fix

### DIFF
--- a/libs/core-kernel/src/main/kotlin/kr/co/jiniaslog/shared/core/domain/DomainEntity.kt
+++ b/libs/core-kernel/src/main/kotlin/kr/co/jiniaslog/shared/core/domain/DomainEntity.kt
@@ -4,13 +4,10 @@ import kr.co.jiniaslog.shared.core.domain.vo.ValueObject
 import java.time.LocalDateTime
 
 abstract class DomainEntity<out T : ValueObject>(
-    var createdAt: LocalDateTime? = null,
-    var updatedAt: LocalDateTime? = null,
+    open var createdAt: LocalDateTime? = null,
+    open var updatedAt: LocalDateTime? = null,
 ) {
-    abstract val entityId: T?
-
-    val isPersisted: Boolean
-        get() = createdAt != null
+    abstract val entityId: T
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/libs/rdb-kernel/build.gradle.kts
+++ b/libs/rdb-kernel/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     springBootConventions
+    `kotlin-kapt`
     kotlin("plugin.jpa")
 }
 
@@ -7,4 +8,6 @@ dependencies {
     api(project(Modules.Libs.CoreKernel.path))
     api(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.boot.starter.spy)
+    implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
+    kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
 }

--- a/libs/rdb-kernel/src/main/kotlin/kr/co/jiniaslog/shared/adapter/out/rdb/AuditingAggregateListener.kt
+++ b/libs/rdb-kernel/src/main/kotlin/kr/co/jiniaslog/shared/adapter/out/rdb/AuditingAggregateListener.kt
@@ -1,0 +1,24 @@
+package kr.co.jiniaslog.shared.adapter.out.rdb
+
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import org.springframework.beans.factory.annotation.Configurable
+import java.time.LocalDateTime
+
+@Configurable
+class AuditingAggregateListener {
+    @PrePersist
+    fun touchForCreate(target: Any) {
+        if (target is JpaAggregate<*>) {
+            target.createdAt = LocalDateTime.now()
+            target.updatedAt = LocalDateTime.now()
+        }
+    }
+
+    @PreUpdate
+    fun touchForUpdate(target: Any) {
+        if (target is JpaAggregate<*>) {
+            target.updatedAt = LocalDateTime.now()
+        }
+    }
+}

--- a/libs/rdb-kernel/src/main/kotlin/kr/co/jiniaslog/shared/adapter/out/rdb/JpaAggregate.kt
+++ b/libs/rdb-kernel/src/main/kotlin/kr/co/jiniaslog/shared/adapter/out/rdb/JpaAggregate.kt
@@ -1,0 +1,30 @@
+package kr.co.jiniaslog.shared.adapter.out.rdb
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import kr.co.jiniaslog.shared.core.domain.AggregateRoot
+import kr.co.jiniaslog.shared.core.domain.vo.ValueObject
+import org.springframework.data.domain.Persistable
+import java.time.LocalDateTime
+
+/**
+ * JPA용 AggregateRoot
+ *
+ * 영속성 모델을 분리하지 않고 도메인 모델을 사용할 경우 JPA의 Audit기능과의 충돌 방지를 위해 사용
+ *
+ * @see AuditingAggregateListener
+ */
+@EntityListeners(AuditingAggregateListener::class)
+@MappedSuperclass
+abstract class JpaAggregate<T : ValueObject> : AggregateRoot<T>(), Persistable<T> {
+    @Column(name = "created_at", nullable = false, updatable = false)
+    override var createdAt: LocalDateTime? = null
+
+    @Column(name = "updated_at", nullable = false)
+    override var updatedAt: LocalDateTime? = null
+
+    override fun isNew(): Boolean = createdAt == null
+
+    override fun getId(): T = entityId
+}

--- a/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/blog/usecase/IStartToWriteNewDraftArticleUseCaseTests.kt
+++ b/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/blog/usecase/IStartToWriteNewDraftArticleUseCaseTests.kt
@@ -7,9 +7,9 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import jakarta.persistence.EntityManager
 import kr.co.jiniaslog.TestContainerAbstractSkeleton
+import kr.co.jiniaslog.blog.domain.UserId
 import kr.co.jiniaslog.blog.domain.article.Article
 import kr.co.jiniaslog.blog.domain.article.ArticleContents
-import kr.co.jiniaslog.blog.domain.user.UserId
 import kr.co.jiniaslog.blog.outbound.persistence.ArticleRepository
 import kr.co.jiniaslog.blog.outbound.persistence.BlogTransactionHandler
 import kr.co.jiniaslog.blog.usecase.article.IStartToWriteNewDraftArticle

--- a/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/blog/usecase/ISyncCategoriesUseCaseTests.kt
+++ b/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/blog/usecase/ISyncCategoriesUseCaseTests.kt
@@ -28,7 +28,9 @@ class ISyncCategoriesUseCaseTests : TestContainerAbstractSkeleton() {
     @Test
     fun `기존 카테고리가 존재하고 새로운 카테고리가 추가되면 동기화가 이루어진다`() {
         // given
-        val (parent1, parent2) = asIsPersistedCategories()
+        val (parent1, parent2) = transactionHandler.run {
+            asIsPersistedCategories()
+        }
 
         val parent1Vo = parent1.toDto()
         var parent2Vo = parent2.toDto()

--- a/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/blog/usecase/ISyncCategoriesUseCaseTests.kt
+++ b/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/blog/usecase/ISyncCategoriesUseCaseTests.kt
@@ -245,153 +245,57 @@ class ISyncCategoriesUseCaseTests : TestContainerAbstractSkeleton() {
     }
 
     @Test
-    fun `새로 생성되는 카테고리들이 연관관계를 가지고 있을때 정상 저장이 된다`() {
+    fun `새로운 카테고리들이 연관관계를 가지고 있어도 정상 저장된다`() {
         // given
-        val parent1 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("parent1"),
-            0,
+        val parent1 = CategoryDataHolder(
+            categoryId = null,
+            categoryName = CategoryTitle("parent1"),
+            sortingPoint = 0,
+            children = listOf(
+                CategoryDataHolder(
+                    categoryId = null,
+                    categoryName = CategoryTitle("child1"),
+                    sortingPoint = 1,
+                    children = listOf(
+                        CategoryDataHolder(
+                            categoryId = null,
+                            categoryName = CategoryTitle("child2"),
+                            sortingPoint = 2,
+                        )
+                    )
+                )
+            )
         )
 
-        val child1OfParent1 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child1"),
-            1,
-        ).apply {
-            changeParent(parent1)
-        }
-
-        val child2OfParent1 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child2"),
-            1,
-        ).apply {
-            changeParent(parent1)
-        }
-
-        val parent2 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("parent2"),
-            0,
+        val parent2 = CategoryDataHolder(
+            categoryId = null,
+            categoryName = CategoryTitle("parent2"),
+            sortingPoint = 0,
+            children = listOf(
+                CategoryDataHolder(
+                    categoryId = null,
+                    categoryName = CategoryTitle("child1"),
+                    sortingPoint = 1,
+                    children = listOf(
+                        CategoryDataHolder(
+                            categoryId = null,
+                            categoryName = CategoryTitle("child2"),
+                            sortingPoint = 2,
+                        )
+                    )
+                )
+            )
         )
-
-        val child1OfParent2 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child1"),
-            1,
-        ).apply {
-            changeParent(parent2)
-        }
-
-        val child2OfParent2 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child2"),
-            1,
-        ).apply {
-            changeParent(parent2)
-        }
-
-        val parent3 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("parent3"),
-            0,
-        )
-
-        val child1OfParent3 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child1"),
-            1,
-        ).apply {
-            changeParent(parent3)
-        }
-
-        val child2OfParent3 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child2"),
-            1,
-        ).apply {
-            changeParent(parent3)
-        }
-
-        val asIsList = listOf(
-            parent1,
-            child1OfParent1,
-            child2OfParent1,
-            parent2,
-            child1OfParent2,
-            child2OfParent2,
-            parent3,
-            child1OfParent3,
-            child2OfParent3,
-        ).map { it.toDto() }
 
         // when
-        sut.handle(ISyncCategories.Command(asIsList))
-
-        // then
-        em.clear()
-        val result = categoryRepository.findAll()
-        result.size shouldBe 9
-    }
-
-    @Test
-    fun `카테고리의 뎁스가 깊어져도 정상 저장된다`() {
-        // given
-        val parent1 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("parent1"),
-            0,
+        sut.handle(
+            ISyncCategories.Command(
+                listOf(
+                    parent1,
+                    parent2,
+                )
+            )
         )
-
-        val child1OfParent1 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child1"),
-            1,
-        ).apply {
-            changeParent(parent1)
-        }
-
-        val child1OfC1P1 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child2"),
-            1,
-        ).apply {
-            changeParent(child1OfParent1)
-        }
-
-        val parent2 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("parent2"),
-            0,
-        )
-
-        val child1OfParent2 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child1"),
-            1,
-        ).apply {
-            changeParent(parent2)
-        }
-
-        val child2OC1P2 = Category(
-            CategoryId(IdUtils.generate()),
-            CategoryTitle("child2"),
-            1,
-        ).apply {
-            changeParent(child1OfParent2)
-        }
-
-        val asIsList = listOf(
-            parent1,
-            child1OfParent1,
-            child1OfC1P1,
-            parent2,
-            child1OfParent2,
-            child2OC1P2,
-        ).map { it.toDto() }
-
-        // when
-        sut.handle(ISyncCategories.Command(asIsList))
 
         // then
         em.clear()

--- a/service/blog/adapter/blog-in-http/src/main/kotlin/kr/co/jiniaslog/blog/adapter/inbound/http/ArticleResources.kt
+++ b/service/blog/adapter/blog-in-http/src/main/kotlin/kr/co/jiniaslog/blog/adapter/inbound/http/ArticleResources.kt
@@ -1,9 +1,9 @@
 package kr.co.jiniaslog.blog.adapter.inbound.http
 
+import kr.co.jiniaslog.blog.domain.UserId
 import kr.co.jiniaslog.blog.domain.article.ArticleId
 import kr.co.jiniaslog.blog.domain.category.CategoryId
 import kr.co.jiniaslog.blog.domain.tag.TagName
-import kr.co.jiniaslog.blog.domain.user.UserId
 import kr.co.jiniaslog.blog.usecase.article.ArticleUseCasesFacade
 import kr.co.jiniaslog.blog.usecase.article.IAddAnyTagInArticle
 import kr.co.jiniaslog.blog.usecase.article.ICategorizeArticle

--- a/service/blog/adapter/blog-out-user/src/main/kotlin/kr/co/jiniaslog/blog/adapter/outbound/user/UserAcl.kt
+++ b/service/blog/adapter/blog-out-user/src/main/kotlin/kr/co/jiniaslog/blog/adapter/outbound/user/UserAcl.kt
@@ -1,6 +1,6 @@
 package kr.co.jiniaslog.blog.adapter.outbound.user
 
-import kr.co.jiniaslog.blog.domain.user.UserId
+import kr.co.jiniaslog.blog.domain.UserId
 import kr.co.jiniaslog.blog.outbound.UserService
 import kr.co.jiniaslog.shared.core.annotation.CustomComponent
 import kr.co.jiniaslog.user.adapter.inbound.acl.UserAclInboundAdapter

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/MemoId.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/MemoId.kt
@@ -1,4 +1,4 @@
-package kr.co.jiniaslog.blog.domain.memo
+package kr.co.jiniaslog.blog.domain
 
 import jakarta.persistence.Embeddable
 import kr.co.jiniaslog.shared.core.domain.vo.ValueObject

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/UserId.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/UserId.kt
@@ -1,4 +1,4 @@
-package kr.co.jiniaslog.blog.domain.user
+package kr.co.jiniaslog.blog.domain
 
 import jakarta.persistence.Embeddable
 import kr.co.jiniaslog.shared.core.domain.vo.ValueObject

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/article/Article.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/article/Article.kt
@@ -6,17 +6,16 @@ import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
+import kr.co.jiniaslog.blog.domain.MemoId
+import kr.co.jiniaslog.blog.domain.UserId
 import kr.co.jiniaslog.blog.domain.category.Category
 import kr.co.jiniaslog.blog.domain.category.CategoryId
-import kr.co.jiniaslog.blog.domain.memo.MemoId
 import kr.co.jiniaslog.blog.domain.tag.Tag
 import kr.co.jiniaslog.blog.domain.tag.TagId
-import kr.co.jiniaslog.blog.domain.user.UserId
-import kr.co.jiniaslog.shared.core.domain.AggregateRoot
+import kr.co.jiniaslog.shared.adapter.out.rdb.JpaAggregate
 import kr.co.jiniaslog.shared.core.domain.IdUtils
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
-import org.springframework.data.domain.Persistable
 
 /**
  * 블로그 게시글
@@ -46,7 +45,7 @@ class Article internal constructor(
     tags: MutableSet<Tagging>,
     categoryId: CategoryId?,
     hit: Int,
-) : AggregateRoot<ArticleId>(), Persistable<ArticleId> {
+) : JpaAggregate<ArticleId>() {
 
     /**
      * 게시글 상태
@@ -57,13 +56,13 @@ class Article internal constructor(
     enum class Status { DRAFT, PUBLISHED, DELETED }
 
     @EmbeddedId
-    @AttributeOverride(column = Column(name = "article_id"), name = "value")
+    @AttributeOverride(column = Column(name = "id"), name = "value")
     override val entityId: ArticleId = id
 
     @AttributeOverride(column = Column(name = "author_id"), name = "value")
     val authorId: UserId = authorId
 
-    @Column(name = "article_status")
+    @Column(name = "status")
     var status: Status = status
         private set
 
@@ -207,14 +206,6 @@ class Article internal constructor(
         require(status != Status.DELETED) { "삭제된 게시글은 태그를 추가할 수 없습니다." }
         val tagging = Tagging(tag.entityId)
         _tags.add(tagging)
-    }
-
-    override fun getId(): ArticleId {
-        return entityId
-    }
-
-    override fun isNew(): Boolean {
-        return isPersisted.not()
     }
 
     companion object {

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/category/Category.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/category/Category.kt
@@ -1,6 +1,7 @@
 package kr.co.jiniaslog.blog.domain.category
 
 import jakarta.persistence.AttributeOverride
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
@@ -40,7 +41,7 @@ class Category(
     var parent: Category? = null
         private set
 
-    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     var children: MutableList<Category> = mutableListOf()
         private set
 

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/category/Category.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/category/Category.kt
@@ -2,15 +2,13 @@ package kr.co.jiniaslog.blog.domain.category
 
 import jakarta.persistence.AttributeOverride
 import jakarta.persistence.Column
-import jakarta.persistence.ConstraintMode
 import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
-import jakarta.persistence.ForeignKey
+import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
-import kr.co.jiniaslog.shared.core.domain.AggregateRoot
-import org.springframework.data.domain.Persistable
+import kr.co.jiniaslog.shared.adapter.out.rdb.JpaAggregate
 
 /**
  * 카테고리 어그리게이트 루트
@@ -22,31 +20,31 @@ class Category(
     id: CategoryId,
     categoryTitle: CategoryTitle,
     sortingPoint: Int,
-) : AggregateRoot<CategoryId>(), Persistable<CategoryId> {
+) : JpaAggregate<CategoryId>() {
     @EmbeddedId
     @AttributeOverride(
-        column = Column(name = "category_id"),
+        column = Column(name = "id"),
         name = "value",
     )
     override val entityId: CategoryId = id
 
     @AttributeOverride(
-        column = Column(name = "category_title"),
+        column = Column(name = "title"),
         name = "value",
     )
     var categoryTitle: CategoryTitle = categoryTitle
         private set
 
-    // fixme persistable 관련 문제로 삭제예정
-    @ManyToOne
-    @JoinColumn(name = "parent_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
     var parent: Category? = null
         private set
 
-    @OneToMany(mappedBy = "parent")
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
     var children: MutableList<Category> = mutableListOf()
         private set
 
+    @Column(name = "sorting_point")
     var sortingPoint: Int = sortingPoint
         private set
 
@@ -71,13 +69,5 @@ class Category(
         this.categoryTitle = categoryTitle
         this.sortingPoint = sortingPoint
         this.parent = parent
-    }
-
-    override fun getId(): CategoryId {
-        return entityId
-    }
-
-    override fun isNew(): Boolean {
-        return isPersisted.not()
     }
 }

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/tag/Tag.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/domain/tag/Tag.kt
@@ -6,15 +6,14 @@ import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.PrePersist
 import jakarta.persistence.PreUpdate
-import kr.co.jiniaslog.shared.core.domain.AggregateRoot
+import kr.co.jiniaslog.shared.adapter.out.rdb.JpaAggregate
 import kr.co.jiniaslog.shared.core.domain.IdUtils
-import org.springframework.data.domain.Persistable
 
 @Entity
 class Tag private constructor(
     id: TagId,
     name: TagName,
-) : AggregateRoot<TagId>(), Persistable<TagId> {
+) : JpaAggregate<TagId>() {
     @EmbeddedId
     @AttributeOverride(
         column = Column(name = "tag_id"),
@@ -36,13 +35,5 @@ class Tag private constructor(
         fun newOne(name: TagName): Tag {
             return Tag(TagId(IdUtils.generate()), name)
         }
-    }
-
-    override fun getId(): TagId {
-        return entityId
-    }
-
-    override fun isNew(): Boolean {
-        return isPersisted.not()
     }
 }

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/UserService.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/UserService.kt
@@ -1,6 +1,6 @@
 package kr.co.jiniaslog.blog.outbound
 
-import kr.co.jiniaslog.blog.domain.user.UserId
+import kr.co.jiniaslog.blog.domain.UserId
 
 interface UserService {
     fun isExistUser(id: UserId): Boolean

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/persistence/ArticleRepository.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/persistence/ArticleRepository.kt
@@ -1,13 +1,9 @@
 package kr.co.jiniaslog.blog.outbound.persistence
 
-import com.querydsl.jpa.impl.JPAQueryFactory
 import kr.co.jiniaslog.blog.domain.article.Article
 import kr.co.jiniaslog.blog.domain.article.ArticleId
-import kr.co.jiniaslog.blog.domain.article.QArticle.article
 import kr.co.jiniaslog.shared.core.domain.Repository
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 interface ArticleRepository : Repository<Article, ArticleId>
 
@@ -16,7 +12,6 @@ interface ArticleJpaRepository : JpaRepository<Article, ArticleId>
 @org.springframework.stereotype.Repository
 class ArticleRepositoryAdapter(
     private val articleJpaRepository: ArticleJpaRepository,
-    private val jpaQueryFactory: JPAQueryFactory
 ) : ArticleRepository {
     override fun save(entity: Article): Article {
         return articleJpaRepository.save(entity)
@@ -26,11 +21,7 @@ class ArticleRepositoryAdapter(
         return articleJpaRepository.findById(id).orElse(null)
     }
 
-    @Transactional("blogTransactionManager", isolation = Isolation.REPEATABLE_READ)
     override fun deleteById(id: ArticleId) {
-        jpaQueryFactory
-            .delete(article)
-            .where(article.entityId.eq(id))
-            .execute()
+        articleJpaRepository.deleteById(id)
     }
 }

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/persistence/CategoryRepository.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/persistence/CategoryRepository.kt
@@ -1,5 +1,6 @@
 package kr.co.jiniaslog.blog.outbound.persistence
 
+import jakarta.persistence.EntityManager
 import kr.co.jiniaslog.blog.domain.category.Category
 import kr.co.jiniaslog.blog.domain.category.CategoryId
 import kr.co.jiniaslog.shared.core.domain.Repository
@@ -10,14 +11,15 @@ interface CategoryRepository : Repository<Category, CategoryId> {
 
     fun deleteAll(list: List<Category>)
 
-    fun saveAll(list: List<Category>): List<Category>
+    fun saveAll(list: List<Category>)
 }
 
 interface CategoryJpaRepository : JpaRepository<Category, CategoryId>
 
 @org.springframework.stereotype.Repository
 class CategoryRepositoryAdapter(
-    private val categoryJpaRepository: CategoryJpaRepository
+    private val categoryJpaRepository: CategoryJpaRepository,
+    private val entityManager: EntityManager
 ) : CategoryRepository {
     override fun save(entity: Category): Category {
         return categoryJpaRepository.save(entity)
@@ -31,8 +33,11 @@ class CategoryRepositoryAdapter(
         return categoryJpaRepository.deleteAll(list)
     }
 
-    override fun saveAll(list: List<Category>): List<Category> {
-        return categoryJpaRepository.saveAll(list)
+    override fun saveAll(list: List<Category>) {
+        // persistable isNew의 동작 문제로 연관관계 매핑된 객체 저장시 cascade 만 이용하여 저장하도록 조절
+        // 최상위 부모만 저장하고 나머지는 cascade로 저장토록 한다
+        val target = list.filter { it.parent == null }
+        categoryJpaRepository.saveAll(target)
     }
 
     override fun findById(id: CategoryId): Category? {

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/persistence/CategoryRepository.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/persistence/CategoryRepository.kt
@@ -1,9 +1,7 @@
 package kr.co.jiniaslog.blog.outbound.persistence
 
-import com.querydsl.jpa.impl.JPAQueryFactory
 import kr.co.jiniaslog.blog.domain.category.Category
 import kr.co.jiniaslog.blog.domain.category.CategoryId
-import kr.co.jiniaslog.blog.domain.category.QCategory.category
 import kr.co.jiniaslog.shared.core.domain.Repository
 import org.springframework.data.jpa.repository.JpaRepository
 
@@ -19,8 +17,7 @@ interface CategoryJpaRepository : JpaRepository<Category, CategoryId>
 
 @org.springframework.stereotype.Repository
 class CategoryRepositoryAdapter(
-    private val categoryJpaRepository: CategoryJpaRepository,
-    private val jpaQueryFactory: JPAQueryFactory
+    private val categoryJpaRepository: CategoryJpaRepository
 ) : CategoryRepository {
     override fun save(entity: Category): Category {
         return categoryJpaRepository.save(entity)
@@ -31,10 +28,7 @@ class CategoryRepositoryAdapter(
     }
 
     override fun deleteAll(list: List<Category>) {
-//        return categoryJpaRepository.deleteAll(list)
-        list.forEach {
-            deleteById(it.entityId)
-        }
+        return categoryJpaRepository.deleteAll(list)
     }
 
     override fun saveAll(list: List<Category>): List<Category> {
@@ -46,9 +40,6 @@ class CategoryRepositoryAdapter(
     }
 
     override fun deleteById(id: CategoryId) {
-//        categoryJpaRepository.deleteById(id)
-        jpaQueryFactory.delete(category)
-            .where(category.entityId.eq(id))
-            .execute()
+        categoryJpaRepository.deleteById(id)
     }
 }

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/persistence/TagJpaRepository.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/outbound/persistence/TagJpaRepository.kt
@@ -2,7 +2,6 @@ package kr.co.jiniaslog.blog.outbound.persistence
 
 import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
-import jakarta.persistence.EntityManager
 import kr.co.jiniaslog.blog.domain.article.QArticle.article
 import kr.co.jiniaslog.blog.domain.article.QTagging.tagging
 import kr.co.jiniaslog.blog.domain.tag.QTag.tag
@@ -11,8 +10,6 @@ import kr.co.jiniaslog.blog.domain.tag.TagId
 import kr.co.jiniaslog.blog.domain.tag.TagName
 import kr.co.jiniaslog.shared.core.domain.Repository
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 interface TagJpaRepository : JpaRepository<Tag, TagId> {
     fun findByTagName(tagName: TagName): Tag?
@@ -28,7 +25,6 @@ interface TagRepository : Repository<Tag, TagId> {
 class TagRepositoryAdapter(
     private val tagJpaRepository: TagJpaRepository,
     private val queryFactory: JPAQueryFactory,
-    private val em: EntityManager
 ) : TagRepository {
     override fun save(entity: Tag): Tag {
         return tagJpaRepository.save(entity)
@@ -55,12 +51,7 @@ class TagRepositoryAdapter(
         return tagJpaRepository.findById(id).orElse(null)
     }
 
-    // fixme 대체 왜 안됨?
-    @Transactional("blogTransactionManager", isolation = Isolation.REPEATABLE_READ)
     override fun deleteById(id: TagId) {
-        queryFactory.delete(tag)
-            .where(tag.entityId.eq(id))
-            .execute()
-//        tagJpaRepository.deleteById(id)
+        tagJpaRepository.deleteById(id)
     }
 }

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/usecase/CategoryUseCaseInteractor.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/usecase/CategoryUseCaseInteractor.kt
@@ -19,7 +19,8 @@ class CategoryUseCaseInteractor(
                 asIs = asIsCategories,
                 toBe = command.toBeSyncCategories
             )
-            categoryRepository.saveAll(result.toBeUpsert)
+            categoryRepository.saveAll(result.toBeInsert)
+            categoryRepository.saveAll(result.toBeUpdate)
             categoryRepository.deleteAll(result.toBeDelete)
         }
         return ISyncCategories.Info()

--- a/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/usecase/article/IStartToWriteNewDraftArticle.kt
+++ b/service/blog/blog-core/src/main/kotlin/kr/co/jiniaslog/blog/usecase/article/IStartToWriteNewDraftArticle.kt
@@ -1,7 +1,7 @@
 package kr.co.jiniaslog.blog.usecase.article
 
+import kr.co.jiniaslog.blog.domain.UserId
 import kr.co.jiniaslog.blog.domain.article.ArticleId
-import kr.co.jiniaslog.blog.domain.user.UserId
 
 interface IStartToWriteNewDraftArticle {
     fun handle(command: Command): Info

--- a/service/blog/blog-core/src/test/kotlin/kr/co/jiniaslog/blog/domain/article/ArticleTests.kt
+++ b/service/blog/blog-core/src/test/kotlin/kr/co/jiniaslog/blog/domain/article/ArticleTests.kt
@@ -4,13 +4,13 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import kr.co.jiniaslog.blog.domain.ArticleTestFixtures
+import kr.co.jiniaslog.blog.domain.UserId
 import kr.co.jiniaslog.blog.domain.category.Category
 import kr.co.jiniaslog.blog.domain.category.CategoryId
 import kr.co.jiniaslog.blog.domain.category.CategoryTitle
 import kr.co.jiniaslog.blog.domain.tag.Tag
 import kr.co.jiniaslog.blog.domain.tag.TagId
 import kr.co.jiniaslog.blog.domain.tag.TagName
-import kr.co.jiniaslog.blog.domain.user.UserId
 import kr.co.jiniaslog.shared.SimpleUnitTestContext
 import kr.co.jiniaslog.shared.core.domain.IdUtils
 import org.junit.jupiter.api.Nested

--- a/service/blog/blog-core/src/test/kotlin/kr/co/jiniaslog/blog/domain/category/CategorySyncerTest.kt
+++ b/service/blog/blog-core/src/test/kotlin/kr/co/jiniaslog/blog/domain/category/CategorySyncerTest.kt
@@ -64,8 +64,10 @@ class CategorySyncerTest : SimpleUnitTestContext() {
 
         // then
         result.toBeDelete.isEmpty() shouldBe true
-        result.toBeUpsert.isNotEmpty() shouldBe true
-        result.toBeUpsert.size shouldBe 5
+        result.toBeInsert.isNotEmpty() shouldBe true
+        result.toBeInsert.size shouldBe 1
+        result.toBeUpdate.isNotEmpty() shouldBe true
+        result.toBeUpdate.size shouldBe 4
     }
 
     @Test
@@ -146,8 +148,11 @@ class CategorySyncerTest : SimpleUnitTestContext() {
 
         // then
         result.toBeDelete.isEmpty() shouldBe true
-        result.toBeUpsert.isNotEmpty() shouldBe true
-        result.toBeUpsert.size shouldBe 6
+        result.toBeUpdate.isNotEmpty() shouldBe true
+        result.toBeInsert.isNotEmpty() shouldBe true
+
+        result.toBeInsert.size shouldBe 2
+        result.toBeUpdate.size shouldBe 4
     }
 
     @Test
@@ -229,9 +234,12 @@ class CategorySyncerTest : SimpleUnitTestContext() {
 
         // then
         result.toBeDelete.isEmpty() shouldBe true
-        result.toBeUpsert.isNotEmpty() shouldBe true
-        result.toBeUpsert.size shouldBe 6
-        result.toBeUpsert.first { it.entityId == parent2.entityId }.categoryTitle.value shouldBe "수정"
+        result.toBeUpdate.isNotEmpty() shouldBe true
+        result.toBeUpdate.size shouldBe 4
+        result.toBeUpdate.first { it.entityId == parent2.entityId }.categoryTitle.value shouldBe "수정"
+
+        result.toBeInsert.isNotEmpty() shouldBe true
+        result.toBeInsert.size shouldBe 2
     }
 
     @Test
@@ -312,9 +320,11 @@ class CategorySyncerTest : SimpleUnitTestContext() {
 
         // then
         result.toBeDelete.isNotEmpty() shouldBe true
-        result.toBeUpsert.isNotEmpty() shouldBe true
         result.toBeDelete.size shouldBe 3
-        result.toBeUpsert.size shouldBe 3
-        result.toBeUpsert.first { it.entityId == parent2.entityId }.categoryTitle.value shouldBe "수정"
+        result.toBeUpdate.isNotEmpty() shouldBe true
+        result.toBeUpdate.size shouldBe 1
+        result.toBeInsert.isNotEmpty() shouldBe true
+        result.toBeInsert.size shouldBe 2
+        result.toBeUpdate.first { it.entityId == parent2.entityId }.categoryTitle.value shouldBe "수정"
     }
 }

--- a/service/blog/blog-core/src/test/kotlin/kr/co/jiniaslog/blog/domain/memo/MemoVoFragmentsTests.kt
+++ b/service/blog/blog-core/src/test/kotlin/kr/co/jiniaslog/blog/domain/memo/MemoVoFragmentsTests.kt
@@ -1,6 +1,7 @@
 package kr.co.jiniaslog.blog.domain.memo
 
 import io.kotest.assertions.throwables.shouldThrow
+import kr.co.jiniaslog.blog.domain.MemoId
 import org.junit.jupiter.api.Test
 
 class MemoVoFragmentsTests {

--- a/service/blog/blog-core/src/test/kotlin/kr/co/jiniaslog/blog/domain/user/UserVoFragmentsTests.kt
+++ b/service/blog/blog-core/src/test/kotlin/kr/co/jiniaslog/blog/domain/user/UserVoFragmentsTests.kt
@@ -1,6 +1,7 @@
 package kr.co.jiniaslog.blog.domain.user
 
 import io.kotest.assertions.throwables.shouldThrow
+import kr.co.jiniaslog.blog.domain.UserId
 import org.junit.jupiter.api.Test
 
 class UserVoFragmentsTests {

--- a/service/blog/blog-core/src/testFixtures/kotlin/kr/co/jiniaslog/blog/domain/ArticleTestFixtures.kt
+++ b/service/blog/blog-core/src/testFixtures/kotlin/kr/co/jiniaslog/blog/domain/ArticleTestFixtures.kt
@@ -5,9 +5,7 @@ import kr.co.jiniaslog.blog.domain.article.ArticleContents
 import kr.co.jiniaslog.blog.domain.article.ArticleId
 import kr.co.jiniaslog.blog.domain.article.Tagging
 import kr.co.jiniaslog.blog.domain.category.CategoryId
-import kr.co.jiniaslog.blog.domain.memo.MemoId
 import kr.co.jiniaslog.blog.domain.tag.TagId
-import kr.co.jiniaslog.blog.domain.user.UserId
 import kr.co.jiniaslog.shared.core.domain.IdUtils
 import java.time.LocalDateTime
 

--- a/service/memo/memo-domain/src/test/kotlin/kr/co/jiniaslog/memo/domain/memo/MemoTests.kt
+++ b/service/memo/memo-domain/src/test/kotlin/kr/co/jiniaslog/memo/domain/memo/MemoTests.kt
@@ -18,7 +18,7 @@ internal class MemoTests : CustomBehaviorSpec() {
                     sutMemo.authorId shouldBe authorId
                 }
                 Then("persist 되지 않은상태여야한다") {
-                    sutMemo.isPersisted shouldBe false
+                    sutMemo.createdAt shouldBe null
                 }
             }
         }


### PR DESCRIPTION
# 문제 1 persistable 에 사용할 createAt의 audit 미구현 문제

- 상속받는 추상 클래스의 모듈이 jpa 의존성이 없음

- jpa용 aggregate model을 재정의하여 거기서 listener를 재정의해 사용

# 문제 2 연관관계가 매핑되어있는 엔티티 저장시 persistable 인지 문제

- 가설 : 연관관계를 가지고 있는경우 연관된 엔티티의 flush에 따른 더티체킹 동작이 persistable을 제대로 사용하지 않는듯하다

- 우회책 : update / insert 분리로 insert를 먼저 수행, 또한 최상위 부모만 영속화하고 하위는 cascade로 처리하도록 수정


