### PR TITLE
Revert "neo4j 생성방식에 따른 양방향 순환관계 에러 해결 (#63)"

### DIFF
--- a/service/memo/adapter/memo-out-neo4j/src/main/kotlin/kr/co/jiniaslog/memo/adapter/out/neo4j/folder/FolderNeo4jEntity.kt
+++ b/service/memo/adapter/memo-out-neo4j/src/main/kotlin/kr/co/jiniaslog/memo/adapter/out/neo4j/folder/FolderNeo4jEntity.kt
@@ -1,12 +1,10 @@
 package kr.co.jiniaslog.memo.adapter.out.neo4j.folder
 
 import kr.co.jiniaslog.memo.adapter.out.neo4j.Neo4jAbstractBaseNode
-import kr.co.jiniaslog.memo.adapter.out.neo4j.memo.MemoNeo4jEntity
 import kr.co.jiniaslog.memo.domain.folder.Folder
 import kr.co.jiniaslog.memo.domain.folder.FolderId
 import kr.co.jiniaslog.memo.domain.folder.FolderName
 import kr.co.jiniaslog.memo.domain.memo.AuthorId
-import org.springframework.data.annotation.PersistenceCreator
 import org.springframework.data.neo4j.core.schema.Id
 import org.springframework.data.neo4j.core.schema.Node
 import org.springframework.data.neo4j.core.schema.Property
@@ -23,22 +21,9 @@ internal class FolderNeo4jEntity(
     val authorId: Long,
     @Relationship(type = "CONTAINS", direction = Relationship.Direction.INCOMING)
     var parent: FolderNeo4jEntity?,
-    @Relationship(type = "CONTAINS", direction = Relationship.Direction.OUTGOING)
-    var children: MutableSet<FolderNeo4jEntity> = mutableSetOf(),
-    @Relationship(type = "CONTAINS_MEMO", direction = Relationship.Direction.OUTGOING)
-    var memos: MutableSet<MemoNeo4jEntity> = mutableSetOf(),
     createdAt: LocalDateTime?,
     updatedAt: LocalDateTime?,
 ) : Neo4jAbstractBaseNode(createdAt, updatedAt) {
-    @PersistenceCreator
-    constructor(
-        id: Long,
-        name: String,
-        authorId: Long,
-        createdAt: LocalDateTime?,
-        updatedAt: LocalDateTime?
-    ) : this(id, name, authorId, null, mutableSetOf(), mutableSetOf(), createdAt, updatedAt)
-
     fun toDomain(): Folder {
         return Folder.from(
             id = FolderId(this.id),

--- a/service/memo/adapter/memo-out-neo4j/src/main/kotlin/kr/co/jiniaslog/memo/adapter/out/neo4j/folder/FolderNeo4jRepository.kt
+++ b/service/memo/adapter/memo-out-neo4j/src/main/kotlin/kr/co/jiniaslog/memo/adapter/out/neo4j/folder/FolderNeo4jRepository.kt
@@ -23,14 +23,5 @@ DETACH DELETE parentFolder, childFolder, memo1, memo2
         @Param("folderId") folderId: Long,
     )
 
-    @Query(
-        """
-    MATCH (f:folder)-[a:CONTAINS*0..]->(f2:folder)
-    WHERE f.authorId = ${'$'}authorId
-    WITH f, f2, a
-    OPTIONAL MATCH (f)-[b:CONTAINS_MEMO]->(m:memo)
-    OPTIONAL MATCH (m)-[c:REFERENCE]->(ref:memo)
-RETURN f, collect(f2) AS children, collect(m) AS memos, collect(ref) AS references, collect(a) AS contains, collect(b) AS containsMemo, collect(c) AS reference"""
-    )
-    fun findAllByAuthorId(@Param("authorId") authorId: Long): List<FolderNeo4jEntity>
+    fun findAllByAuthorId(authorId: Long): List<FolderNeo4jEntity>
 }

--- a/service/memo/adapter/memo-out-neo4j/src/main/kotlin/kr/co/jiniaslog/memo/adapter/out/neo4j/memo/MemoNeo4jEntity.kt
+++ b/service/memo/adapter/memo-out-neo4j/src/main/kotlin/kr/co/jiniaslog/memo/adapter/out/neo4j/memo/MemoNeo4jEntity.kt
@@ -9,7 +9,6 @@ import kr.co.jiniaslog.memo.domain.memo.MemoContent
 import kr.co.jiniaslog.memo.domain.memo.MemoId
 import kr.co.jiniaslog.memo.domain.memo.MemoReference
 import kr.co.jiniaslog.memo.domain.memo.MemoTitle
-import org.springframework.data.annotation.PersistenceCreator
 import org.springframework.data.neo4j.core.schema.Id
 import org.springframework.data.neo4j.core.schema.Node
 import org.springframework.data.neo4j.core.schema.Property
@@ -28,23 +27,11 @@ internal class MemoNeo4jEntity(
     var content: String,
     @Relationship(type = "REFERENCE", direction = Relationship.Direction.OUTGOING)
     var references: MutableSet<MemoNeo4jEntity>,
-    @Relationship(type = "REFERENCE", direction = Relationship.Direction.INCOMING)
-    var referencedBy: MutableSet<MemoNeo4jEntity> = mutableSetOf(),
     @Relationship(type = "CONTAINS_MEMO", direction = Relationship.Direction.INCOMING)
     var parentFolder: FolderNeo4jEntity?,
     createdAt: LocalDateTime?,
     updatedAt: LocalDateTime?,
 ) : Neo4jAbstractBaseNode(createdAt, updatedAt) {
-    @PersistenceCreator
-    constructor(
-        id: Long,
-        authorId: Long,
-        title: String,
-        content: String,
-        createdAt: LocalDateTime?,
-        updatedAt: LocalDateTime?,
-    ) : this(id, authorId, title, content, mutableSetOf(), mutableSetOf(), null, createdAt, updatedAt)
-
     fun toDomain(): Memo {
         return Memo.from(
             id = MemoId(this.id),

--- a/service/memo/adapter/memo-out-neo4j/src/main/kotlin/kr/co/jiniaslog/memo/adapter/out/neo4j/memo/MemoNeo4jRepository.kt
+++ b/service/memo/adapter/memo-out-neo4j/src/main/kotlin/kr/co/jiniaslog/memo/adapter/out/neo4j/memo/MemoNeo4jRepository.kt
@@ -58,14 +58,5 @@ internal interface MemoNeo4jRepository : Neo4jRepository<MemoNeo4jEntity, Long> 
     @Query("MATCH (referencingMemo:memo)-[r:REFERENCE]->(m:memo) WHERE m.id = ${'$'}memoId RETURN referencingMemo")
     fun findReferencingMemos(memoId: Long): List<MemoNeo4jEntity>
 
-    @Query(
-        """
-MATCH (m:memo)
-WHERE m.authorId = ${'$'}authorId 
-  AND NOT (()-[:CONTAINS_MEMO]->(m))
-OPTIONAL MATCH (m)-[r:REFERENCE]->(referencedMemo:memo)
-RETURN m, collect(r), collect(referencedMemo)
-"""
-    )
-    fun findAllByAuthorIdAndParentFolderIsNull(authorId: Long): List<MemoNeo4jEntity>
+    fun findAllByAuthorId(authorId: Long): List<MemoNeo4jEntity>
 }


### PR DESCRIPTION
This reverts commit 46664840e5c83b41b0f73cfa828b82c8b083304d.


SDN은 즉시로딩밖에 안하고 순환매핑시 말도안되는 N+1 쿼리가 날라감

이거 어떻게쓰라는거지? 동작이 정말 형편없다

프로덕트레벨에서 쓸수 있는 물건이 아닌듯