### PR TITLE
Fix AuthUserId @see reference

### DIFF
--- a/libs/rest-kernel/src/main/kotlin/kr/cojiniaslog/shared/adapter/inbound/http/AuthUserId.kt
+++ b/libs/rest-kernel/src/main/kotlin/kr/cojiniaslog/shared/adapter/inbound/http/AuthUserId.kt
@@ -5,7 +5,7 @@ package kr.cojiniaslog.shared.adapter.inbound.http
  *
  * 인증정보가 없는 유저 접근시 argument resolver 에서 null 을 반환할수 있으므로 사용시 항상 nullable 해야함
  *
- * @see kr.co.jiniaslog.shared.security.AuthUserIdArgumentResolver
+ * @see kr.co.jiniaslog.shared.config.AuthUserIdArgumentResolver
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)


### PR DESCRIPTION
## Summary
- correct the `@see` tag in `AuthUserId` annotation
- rebuild javadoc documentation

## Testing
- `./gradlew javadoc`

------
https://chatgpt.com/codex/tasks/task_e_683fad4be62c832e8600f51862fd896c