### PR TITLE
Fix TokenManager naming

### DIFF
--- a/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/RestTestAbstractSkeleton.kt
+++ b/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/RestTestAbstractSkeleton.kt
@@ -20,7 +20,7 @@ import kr.co.jiniaslog.user.application.security.AuthProvider
 import kr.co.jiniaslog.user.application.security.PreAuthFilter
 import kr.co.jiniaslog.user.application.security.SecurityConfig
 import kr.co.jiniaslog.user.application.usecase.UseCasesUserAuthFacade
-import kr.co.jiniaslog.user.domain.auth.token.TokenManger
+import kr.co.jiniaslog.user.domain.auth.token.TokenManager
 import kr.co.jiniaslog.user.domain.user.Role
 import kr.co.jiniaslog.user.domain.user.UserId
 import org.junit.jupiter.api.BeforeEach
@@ -41,7 +41,7 @@ class SecurityTestContextConfig {
 
     @Bean
     fun preAuthFilter(
-        jwtTokenManager: TokenManger,
+        jwtTokenManager: TokenManager,
         authenticationProvider: AuthProvider,
     ): PreAuthFilter {
         return PreAuthFilter(jwtTokenManager, authenticationProvider)
@@ -63,7 +63,7 @@ abstract class RestTestAbstractSkeleton {
     private lateinit var mockMvc: MockMvc
 
     @Autowired
-    private lateinit var tokenManager: TokenManger
+    private lateinit var tokenManager: TokenManager
 
     @MockkBean
     protected lateinit var imageService: ImageUseCasesFacade

--- a/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/WebSocketTestAbstractSkeleton.kt
+++ b/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/WebSocketTestAbstractSkeleton.kt
@@ -3,7 +3,7 @@ package kr.co.jiniaslog
 import com.ninjasquad.springmockk.MockkBean
 import kr.co.jiniaslog.blog.usecase.article.ArticleUseCasesFacade
 import kr.co.jiniaslog.memo.usecase.MemoUseCasesFacade
-import kr.co.jiniaslog.user.domain.auth.token.TokenManger
+import kr.co.jiniaslog.user.domain.auth.token.TokenManager
 import kr.co.jiniaslog.user.domain.user.Role
 import kr.co.jiniaslog.user.domain.user.UserId
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ abstract class WebSocketTestAbstractSkeleton {
     protected lateinit var subscribeFuture: CompletableFuture<Any>
 
     @Autowired
-    private lateinit var tokenManager: TokenManger
+    private lateinit var tokenManager: TokenManager
 
     @Test
     fun contextLoads() {

--- a/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/user/UserUseCasesTests.kt
+++ b/mains/monolith-main/src/test/kotlin/kr/co/jiniaslog/user/UserUseCasesTests.kt
@@ -18,7 +18,7 @@ import kr.co.jiniaslog.user.domain.auth.provider.Provider
 import kr.co.jiniaslog.user.domain.auth.token.AccessToken
 import kr.co.jiniaslog.user.domain.auth.token.AuthorizationCode
 import kr.co.jiniaslog.user.domain.auth.token.RefreshToken
-import kr.co.jiniaslog.user.domain.auth.token.TokenManger
+import kr.co.jiniaslog.user.domain.auth.token.TokenManager
 import kr.co.jiniaslog.user.domain.user.Email
 import kr.co.jiniaslog.user.domain.user.NickName
 import kr.co.jiniaslog.user.domain.user.Role
@@ -62,7 +62,7 @@ class UserUseCasesTests : TestContainerAbstractSkeleton() {
         lateinit var sut: IRefreshToken
 
         @Autowired
-        lateinit var tokenManger: TokenManger
+        lateinit var tokenManager: TokenManager
 
         @Autowired
         lateinit var tokenStore: TokenStore
@@ -87,7 +87,7 @@ class UserUseCasesTests : TestContainerAbstractSkeleton() {
         @Test
         fun `포멧이 유효한 리프레시 토큰이여도 스토어에 저장되어있지 않다면 실패한다`() {
             // given
-            val refreshToken = tokenManger.generateRefreshToken(UserId(1L), setOf(Role.USER))
+            val refreshToken = tokenManager.generateRefreshToken(UserId(1L), setOf(Role.USER))
 
             val command =
                 IRefreshToken.Command(
@@ -105,10 +105,10 @@ class UserUseCasesTests : TestContainerAbstractSkeleton() {
             // given context
             val user = userRepository.save(User.newOne(NickName("test"), Email("jinia@test.com"), null))
 
-            val accessToken = tokenManger.generateAccessToken(user.entityId, setOf(Role.USER))
-            val tempRefreshToken = tokenManger.generateRefreshToken(user.entityId, setOf(Role.USER))
+            val accessToken = tokenManager.generateAccessToken(user.entityId, setOf(Role.USER))
+            val tempRefreshToken = tokenManager.generateRefreshToken(user.entityId, setOf(Role.USER))
             tokenStore.save(user.entityId, accessToken, tempRefreshToken)
-            val newRefreshToken = tokenManger.generateRefreshToken(user.entityId, setOf(Role.USER))
+            val newRefreshToken = tokenManager.generateRefreshToken(user.entityId, setOf(Role.USER))
             tokenStore.save(user.entityId, accessToken, newRefreshToken)
 
             val command =
@@ -138,8 +138,8 @@ class UserUseCasesTests : TestContainerAbstractSkeleton() {
             // given context
             val user = userRepository.save(User.newOne(NickName("test"), Email("jinia@test.com"), null))
             val userId = user.entityId
-            val accessToken = tokenManger.generateAccessToken(userId, setOf(Role.USER))
-            val refreshToken = tokenManger.generateRefreshToken(userId, setOf(Role.USER))
+            val accessToken = tokenManager.generateAccessToken(userId, setOf(Role.USER))
+            val refreshToken = tokenManager.generateRefreshToken(userId, setOf(Role.USER))
             tokenStore.save(userId, accessToken, refreshToken)
 
             Thread.sleep(6000)
@@ -170,8 +170,8 @@ class UserUseCasesTests : TestContainerAbstractSkeleton() {
             // given
             val user = userRepository.save(User.newOne(NickName("test"), Email("jinia@test.com"), null))
             val userId = user.entityId
-            val accessToken = tokenManger.generateAccessToken(userId, setOf(Role.USER))
-            val refreshToken = tokenManger.generateRefreshToken(userId, setOf(Role.USER))
+            val accessToken = tokenManager.generateAccessToken(userId, setOf(Role.USER))
+            val refreshToken = tokenManager.generateRefreshToken(userId, setOf(Role.USER))
             tokenStore.save(userId, accessToken, refreshToken)
 
             Thread.sleep(6000)

--- a/service/user-auth/user-auth-application/src/main/kotlin/kr/co/jiniaslog/user/application/security/AccessTokenConfig.kt
+++ b/service/user-auth/user-auth-application/src/main/kotlin/kr/co/jiniaslog/user/application/security/AccessTokenConfig.kt
@@ -1,7 +1,7 @@
 package kr.co.jiniaslog.user.application.security
 
 import kr.co.jiniaslog.user.domain.auth.token.JwtTokenManager
-import kr.co.jiniaslog.user.domain.auth.token.TokenManger
+import kr.co.jiniaslog.user.domain.auth.token.TokenManager
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,7 +19,7 @@ class AccessTokenConfig {
     lateinit var refreshTokenValidDuration: Duration
 
     @Bean
-    fun jwtTokenGenerator(): TokenManger {
+    fun jwtTokenGenerator(): TokenManager {
         return JwtTokenManager(secretKey, tokenValidDuration, refreshTokenValidDuration)
     }
 }

--- a/service/user-auth/user-auth-application/src/main/kotlin/kr/co/jiniaslog/user/application/security/PreAuthFilter.kt
+++ b/service/user-auth/user-auth-application/src/main/kotlin/kr/co/jiniaslog/user/application/security/PreAuthFilter.kt
@@ -3,7 +3,7 @@ package kr.co.jiniaslog.user.application.security
 import jakarta.servlet.http.HttpServletRequest
 import kr.co.jiniaslog.user.domain.auth.token.AccessToken
 import kr.co.jiniaslog.user.domain.auth.token.AuthToken
-import kr.co.jiniaslog.user.domain.auth.token.TokenManger
+import kr.co.jiniaslog.user.domain.auth.token.TokenManager
 import org.springframework.security.authentication.ProviderManager
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter
@@ -12,7 +12,7 @@ import java.util.stream.Collectors
 
 @Component
 class PreAuthFilter(
-    private val jwtTokenManager: TokenManger,
+    private val jwtTokenManager: TokenManager,
     authenticationProvider: AuthProvider,
 ) : AbstractPreAuthenticatedProcessingFilter() {
     init {

--- a/service/user-auth/user-auth-domain/src/main/kotlin/kr/co/jiniaslog/user/domain/auth/token/JwtTokenManager.kt
+++ b/service/user-auth/user-auth-domain/src/main/kotlin/kr/co/jiniaslog/user/domain/auth/token/JwtTokenManager.kt
@@ -15,7 +15,7 @@ class JwtTokenManager(
     secretKey: String,
     tokenValidDuration: Duration,
     refreshTokenValidDuration: Duration,
-) : TokenManger {
+) : TokenManager {
     private val roleKey = "roles"
     private val tokenValidDuration = tokenValidDuration.toMillis()
     private val refreshTokenValidDuration = refreshTokenValidDuration.toMillis()

--- a/service/user-auth/user-auth-domain/src/main/kotlin/kr/co/jiniaslog/user/domain/auth/token/TokenManager.kt
+++ b/service/user-auth/user-auth-domain/src/main/kotlin/kr/co/jiniaslog/user/domain/auth/token/TokenManager.kt
@@ -3,7 +3,7 @@ package kr.co.jiniaslog.user.domain.auth.token
 import kr.co.jiniaslog.user.domain.user.Role
 import kr.co.jiniaslog.user.domain.user.UserId
 
-interface TokenManger {
+interface TokenManager {
     fun generateAccessToken(
         id: UserId,
         roles: Set<Role>,


### PR DESCRIPTION
## Summary
- rename `TokenManger` to `TokenManager`
- update all imports and variable names

## Testing
- `./gradlew tasks --no-daemon` *(fails: ksp version incompatibility)*
- `./gradlew :service:user-auth:user-auth-domain:compileKotlin --no-daemon` *(fails: ksp version incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_683fae034874832e9de8595c986748a2